### PR TITLE
Changing line 118 from Associate to Enabled

### DIFF
--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -115,7 +115,7 @@ In this task, you will configure static assignment of public and private IP addr
 
 1. On the **ipconfig1** blade, set **Assignment** to **Static**, leave the default value of **IP address** set to **10.40.0.4**.
 
-1. On the **ipconfig1** blade, in the **Public IP address settings** section, select **Associate** and then click **IP address - Configure required settings**. 
+1. On the **ipconfig1** blade, in the **Public IP address settings** section, select **Enabled** and then click **IP address - Configure required settings**. 
 
 1. On the **Choose public IP address blade**, click **+ Create new** and create a new public IP address with the following settings:
 


### PR DESCRIPTION
I double checked and on the preview version of the portal the name is Associate, on the GA version the options is named Enabled.
This can cause confusion as some students are newbies to Azure. Changing it to the option they have to avoid confusion.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-