### PR TITLE
Lab error/missing step - AZ-104

### DIFF
--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -105,8 +105,9 @@ In this task, you will create an Azure disk resource by using an Azure Resource 
     | Disk Name | **az104-03b-disk1** |
     | Location | accept the default value |
     | Sku | **Standard_LRS** |
-    | Disk Size Gb | **32** |
+    | Disk Size Gb | **32** (No quotes)|
     | Create Option | **empty** |
+    | Encryption Type | **platform** |
 
 1. Select the checkbox **I agree to the terms and conditions stated above** and click **Purchase**.
 


### PR DESCRIPTION
Lab 03b - Manage Azure resources by Using ARM Templates
Task 2: Create an Azure managed disk by using an ARM template
step 9: Back on the Custom deployment blade, specify the following settings:
disk size should be 32 not "32" - should be called out. if you include the "" then the deployment fails
missing encryption type setting - should be platform

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-