### PR TITLE
9a task 6 part 5

### DIFF
--- a/Instructions/Labs/LAB_09a-Implement_Web_Apps.md
+++ b/Instructions/Labs/LAB_09a-Implement_Web_Apps.md
@@ -196,7 +196,7 @@ In this task, you will configure and test autoscaling of Azure web app.
 
     >**Note**: Obviously these values do not represent a realistic configuration, since their purpose is to trigger autoscaling as soon as possible, without extended wait period. 
 
-1. Click **Add** and, back on the **az10408vmss0 - Scaling** blade, specify the following settings (leave others with their default values):
+1. Click **Add** and, back on the **app services plan - scale out** blade, specify the following settings (leave others with their default values):
 
     | Setting | Value |
     | --- |--- |


### PR DESCRIPTION
another error in the 104 labs:
there is a typo in lab 9a task 6 part 5 - looks like a copy paste job from lab 8
Click Add and, back on the az10408vmss0 - Scaling blade, specify the following settings (leave others with their default values):
should be App services plan scaling

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-