### PR TITLE
Update az104-03b-md-parameters.json

### DIFF
--- a/Allfiles/Labs/03/az104-03b-md-parameters.json
+++ b/Allfiles/Labs/03/az104-03b-md-parameters.json
@@ -12,10 +12,13 @@
             "value": "Standard_LRS"
         },
         "diskSizeGb": {
-            "value": "32"
+            "value": 32
         },
         "createOption": {
             "value": "empty"
+        },
+        "diskEncryptionSetType": {
+            "value": "EncryptionAtRestWithPlatformKey"
         }
     }
 }


### PR DESCRIPTION
diskSizeGb value is not a string value.
Added missing parameter diskEncryptionSetType

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-