### PR TITLE
Fix diskSizeGb type from String to Int

### DIFF
--- a/Allfiles/Labs/03/az104-03b-md-template.json
+++ b/Allfiles/Labs/03/az104-03b-md-template.json
@@ -12,7 +12,7 @@
             "type": "String"
         },
         "diskSizeGb": {
-            "type": "String"
+            "type": "Int"
         },
         "sourceResourceId": {
             "type": "String"


### PR DESCRIPTION
# Module: 03
## Lab/Demo: 03b

Changes proposed in this pull request:

Fixes an incorrect type in the ARM template az104-03b-md-template.json . The type of diskSizeInGb is specified as **String** while it should be **Int**.

The issue can be easily reproduced by taking the template and uploading it as a custom template in Azure. The validation will fail.

Note that you would not encounter this issue if you follow the other route described in the lab where you download the template of a previously created disk. There the type is correct.