### PR TITLE
Update LAB_06-Implement_Network_Traffic_Management.md

### DIFF
--- a/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
@@ -126,7 +126,7 @@ In this task, you will configure local peering between the virtual networks you 
     | Name of the peering from az104-06-vnet2 to az104-06-vnet01 | **az104-06-vnet2_to_az104-06-vnet01** |
     | Allow virtual network access from az104-06-vnet01 to az104-06-vnet2 | **Enabled** |
     | Allow virtual network access from az104-06-vnet2 to az104-06-vnet01 | **Enabled** |
-    | Allow forwarded traffic from az104-06-vnet2 to az104-06-vnet01 | **Enabled** |
+    | Allow forwarded traffic from az104-06-vnet2 to az104-06-vnet01 | **Disabled** |
     | Allow forwarded traffic from az104-06-vnet01 to az104-06-vnet2 | **Enabled** |
     | Allow gateway transit | **(Uncheck Box)** |
 
@@ -149,7 +149,7 @@ In this task, you will configure local peering between the virtual networks you 
     | Name of the peering from az104-06-vnet3 to az104-06-vnet01 | **az104-06-vnet3_to_az104-06-vnet01** |
     | Allow virtual network access from az104-06-vnet01 to az104-06-vnet3 | **Enabled** |
     | Allow virtual network access from az104-06-vnet3 to az104-06-vnet01 | **Enabled** |
-    | Allow forwarded traffic from az104-06-vnet3 to az104-06-vnet01 | **Enabled** |
+    | Allow forwarded traffic from az104-06-vnet3 to az104-06-vnet01 | **Disabled** |
     | Allow forwarded traffic from az104-06-vnet01 to az104-06-vnet3 | **Enabled** |
     | Allow gateway transit | **(Uncheck Box)** |
 


### PR DESCRIPTION
I have validated this exercise and "Allow forwarded traffic from az104-06-vnet3 to az104-06-vnet01" and Allow forwarded traffic from az104-06-vnet2 to az104-06-vnet01 need to be disabled as it is not playing role in defined exercise | **Disabled** | . it won't harm but misleading the service chaining fact.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-