### PR TITLE
Update LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md

### DIFF
--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -69,23 +69,19 @@ In this task, you will create an Azure disk resource by using an Azure Resource 
    ```
 
    ```json
-   },
-   "hyperVGeneration": {
-       "defaultValue": "V1",
-       "type": "String"
+"hyperVGeneration": {
+            "defaultValue": "V1",
+            "type": "String"
+        },
    ```
-
-   ```json
-   "osType": "[parameters('osType')]"
+   
+ ```json
+   "osType": "[parameters('osType')]",
    ```
 
     >**Note**: These parameters are removed since they are not applicable to the current deployment. In particular, sourceResourceId, sourceUri, osType, and hyperVGeneration parameters are applicable to creating an Azure disk from an existing VHD file.
 
-1. In addition, remove the trailing comma from the following line:
 
-   ```json
-   "diskSizeGB": "[parameters('diskSizeGb')]",
-   ```
 
     >**Note**: This is necessary to account for the syntax rules of JSON-based ARM templates.
 


### PR DESCRIPTION
The formatting of the removal of the .json is not correct. There is also not a trailing comma as mentioned. The comma is still needed as the networkAccessPolicy is below

                "diskSizeGB": "[parameters('diskSizeGb')]",
                "networkAccessPolicy": "[parameters('networkAccessPolicy')]"
            }

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-