### PR TITLE
Add download link to GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,3 +15,5 @@ markdown: kramdown
 kramdown:
    syntax_highlighter_opts:
       disable : true
+
+theme: jekyll-theme-slate

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: home
 
 # Content Directory
 
-[Required labs files can be DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-104-MicrosoftAzureAdministrator/archive/master.zip)
+Required labs files can be [DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-104-MicrosoftAzureAdministrator/archive/master.zip)
 
 Hyperlinks to each of the lab exercises and demos are listed below.
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ layout: home
 
 Required labs files can be [DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-104-MicrosoftAzureAdministrator/archive/master.zip)
 
-Hyperlinks to each of the lab exercises and demos are listed below.
+Hyperlinks to each of the lab exercises are listed below.
 
 ## Labs
 

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ layout: home
 
 # Content Directory
 
+[Required labs files can be DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-104-MicrosoftAzureAdministrator/archive/master.zip)
+
 Hyperlinks to each of the lab exercises and demos are listed below.
 
 ## Labs


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Fixes 2 .

Changes proposed in this pull request:
1.  Add a link to download the project files (AllFiles in particular) necessary to complete the labs.  Otherwise, learners have to navigate back to the main project page to download the files.
2.  Remove wording referencing Demo links, as there are none.
-
-
-