### PR TITLE
Bold new resource group in all labs

### DIFF
--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -42,7 +42,7 @@ In this task, you will create a virtual network with multiple subnets by using t
     | Setting | Value |
     | --- | --- |
     | Subscription | the name of the Azure subscription you will be using in this lab |
-    | Resource Group | the name of a new resource group **az104-04-rg1** |
+    | Resource Group | the name of a **new** resource group **az104-04-rg1** |
     | Name | **az104-04-vnet1** |
     | Region | the name of any Azure region available in the subscription you will use in this lab |
     | IPv4 address space | **10.40.0.0/20** |


### PR DESCRIPTION
Students continuously miss that the need for a new resource group in these labs based on the way it is written. I also missed this during my first few walkthroughs. If we could simple bold new resource group or make the users more aware in the steps that a new resource group is required

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-