### PR TITLE
highlight new resource group needed

### DIFF
--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -76,7 +76,7 @@ In this task, you will create and configure an Azure Storage account.
     | Setting | Value | 
     | --- | --- |
     | Subscription | the name of the Azure subscription you are using in this lab |
-    | Resource group | the name of a new resource group **az104-07-rg1** |
+    | Resource group | the name of a **new** resource group **az104-07-rg1** |
     | Storage account name | any globally unique name between 3 and 24 in length consisting of letters and digits |
     | Location | the name of an Azure region where you can create an Azure Storage account  |
     | Performance | **Standard** |


### PR DESCRIPTION
If we could bold the step above to display the need for a new resource group this would be more clear a lot of users are missing the need to create a new resource group

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-