### PR TITLE
Removed line 321 as not longer an option in Portal

### DIFF
--- a/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
@@ -318,7 +318,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | Subscription | the name of the Azure subscription you are using in this lab |
     | Resource group | **az104-06-rg3** |
     | Location | the name of the Azure region in which you created the virtual networks |
-    | Virtual network gateway route propagation | **Disabled** |
+
 
    > **Note**: Wait for the route table to be created. This should take about 3 minutes.
 


### PR DESCRIPTION
They've removed enabling virtual network propagation as an option during route table deployment via the Portal.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-