### PR TITLE
Update Storage Account name on line 209

### DIFF
--- a/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
+++ b/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
@@ -184,7 +184,7 @@ In this task, we will use a different policy definition to remediate any non-com
 
 1. On the resource group blade, click **+ Add**.
 
-1. On the **New** blade, search for and select **Storage account - blob, file, table, queue**, and click **Create**. 
+1. On the **New** blade, search for and select **Storage account**, and click **Create**. 
 
 1. On the **Basics** tab of the **Create storage account** blade, specify the following settings (leave others with their defaults) and click **Review + create**:
 


### PR DESCRIPTION
Searching the marketplace for "Storage account - blob, file, table, queue" does not appear when now and only appears if you search "Storage Account". If we could update that to assist in finding this resource easier.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-