### PR TITLE
Fix #155 & reorganize the "hyperVGeneration" block

### DIFF
--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -69,25 +69,11 @@ In this task, you will create an Azure disk resource by using an Azure Resource 
    ```
 
    ```json
-   },
    "hyperVGeneration": {
        "defaultValue": "V1",
        "type": "String"
+   },
    ```
-
-   ```json
-   "osType": "[parameters('osType')]"
-   ```
-
-    >**Note**: These parameters are removed since they are not applicable to the current deployment. In particular, sourceResourceId, sourceUri, osType, and hyperVGeneration parameters are applicable to creating an Azure disk from an existing VHD file.
-
-1. In addition, remove the trailing comma from the following line:
-
-   ```json
-   "diskSizeGB": "[parameters('diskSizeGb')]",
-   ```
-
-    >**Note**: This is necessary to account for the syntax rules of JSON-based ARM templates.
 
 1. Save the changes.
 

--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -75,6 +75,19 @@ In this task, you will create an Azure disk resource by using an Azure Resource 
    },
    ```
 
+   ```json
+   ,
+   "networkAccessPolicy": {
+       "type": "String"
+   }
+   ```
+
+   ```json
+   ,
+   "osType": "[parameters('osType')]",
+   "networkAccessPolicy": "[parameters('networkAccessPolicy')]"
+   ```
+
 1. Save the changes.
 
 1. Back on the **Custom deployment** blade, click **Edit parameters**. 


### PR DESCRIPTION
Fixes #155 by removing unneeded lines from the instructions, and moves the hyperVGeneration closing bracket to AFTER the block, to make clear it is part of that block.

# Module: 3
## Lab/Demo: 3b

Fixes #155 by removing unneeded lines from the instructions, and moves the hyperVGeneration closing bracket to AFTER the block, to make clear it is part of that block.