### PR TITLE
Updated option to select for LB rule due to UI change

### DIFF
--- a/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
@@ -434,7 +434,7 @@ In this task, you will implement an Azure Load Balancer in front of the two Azur
     | Idle timeout (minutes) | **4** |
     | TCP reset | **Disabled** |
     | Floating IP (direct server return) | **Disabled** |
-    | Create implicit outbound rules | **Yes** |
+    | Use outbound rules to provide backend pool members access to the internet. | **Enabled** |
 
 1. Wait for the load balancing rule to be created, click **Overview**, and note the value of the **Public IP address**.
 


### PR DESCRIPTION
The option "Create implicit outbound rules" has been changed to "Use outbound rules to provide backend pool members access to the internet", have the instructions reflect that update to the UI

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-