### PR TITLE
Portal RBAC Interface updated

### DIFF
--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -218,7 +218,7 @@ In this task, you will configure authentication and authorization for Azure Stor
     | Setting | Value |
     | --- | --- |
     | Role | **Storage Blob Data Owner** |
-    | Assign access to | **Azure AD user, group, or service principal** |
+    | Assign access to | **User, group, or service principal** |
     | Select | the name of your user account |
 
 1. Save the change and return to the **Overview** blade of the **az104-07-container** container and verify that you can access to container again.


### PR DESCRIPTION
The Interface for selecting a role assignment no longer includes "Azure AD" in the selection for role assignment it only reads "user, group, or service principal"

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-