### PR TITLE
Storage account not populating

### DIFF
--- a/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
+++ b/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
@@ -91,7 +91,7 @@ In this task, you will deploy Azure virtual machines into different availability
     | Boot diagnostics | **Enable with custom storage account** |
     | Diagnostics storage account | accept the default value |
     
-    >**Note**: Record the name of diagnostics storage account. You will use it in the next task. 
+    >**Note**: If no default storage account populates select the storage account that exists within the dropdown list. Record the name of diagnostics storage account. You will use it in the next task. 
     
 1. Click **Next: Advanced >**, on the **Advanced** tab of the **Create a virtual machine** blade, review the available settings without modifying any of them, and click **Review + Create**.
 


### PR DESCRIPTION
need to guide user when storage account does not populate as deployment will error without making a selection here. Right now the default behavior is that the box is populating empty with no storage account and the user has to select their cloud shell storage account...

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-