### PR TITLE
Clarify tenant initial domain name

### DIFF
--- a/Instructions/Labs/LAB_01-Manage_Azure_AD_Identities.md
+++ b/Instructions/Labs/LAB_01-Manage_Azure_AD_Identities.md
@@ -196,7 +196,7 @@ In this task, you will create a new Azure AD tenant.
     | Initial domain name | any valid DNS name consisting of lower case letters and digits and starting with a letter | 
     | Country/Region | **United States** |
 
-   > **Note**: The green check mark in the **Initial domain name** text box will indicate that the domain name you typed in is valid and unique.
+   > **Note**: The **Initial domain name** should not be a legitimate name that potentially matches your organization or another. The green check mark in the **Initial domain name** text box will indicate that the domain name you typed in is valid and unique.
 
 1. Click **Review + create** and then click **Create**.
 


### PR DESCRIPTION
I wonder how many people have used their own company domain as part of the tenant initial domain, and therefore prevented their company from actually having access to a tenant domain that matches closely with their Internet domain.  My suggestion may not be the best but something should be put in to help ensure students don't accidentally take their corporate tenant domain or another organizations.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-