### PR TITLE
Fix about portal ui changes

### DIFF
--- a/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
+++ b/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
@@ -56,7 +56,7 @@ In this task, you will create and configure management groups.
 
 1. In the list of management groups, click the entry representing the newly created management group and then display its **details**.
 
-1. From the **az104-02-mg1** blade, click **+ Add subscription** and add the subscription you are using in this lab to the management group.
+1. From the **Subscriptions** blade, click **+ Add subscription** and add the subscription you are using in this lab to the management group.
 
     >**Note**: Copy the ID of your Azure subscription into Clipboard. You will need it in the next task.
 

--- a/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
+++ b/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
@@ -173,7 +173,7 @@ In this task, you will create an Azure Active Directory user, assign the RBAC ro
 
 1. In the Azure portal, navigate to the **az104-02-mg1** management group and display its **details**.
 
-1. Right-click the **ellipsis** icon to the right of the entry representing your Azure subscription and click **Move**.
+1. In the **Subscriptions** blade, right-click the **ellipsis** icon to the right of the entry representing your Azure subscription and click **Move**.
 
 1. On the **Move** blade, select the management group which the subscription was originally part of and click **Save**. 
 

--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -140,7 +140,7 @@ In this task, you will create a blob container and upload a blob into it.
 
 1. In the list of containers, click **az104-07-container** and then click **Upload**.
 
-1. Browse to **\\Allfiles\\Labs\\07\\LICENSE** on your lab computer and click **Open**, then click **Upload**.
+1. Browse to **\\Allfiles\\Labs\\07\\LICENSE** on your lab computer and click **Open**.
 
 1. On the **Upload blob** blade, expand the **Advanced** section and specify the following settings (leave others with their default values):
 

--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -207,6 +207,8 @@ In this task, you will configure authentication and authorization for Azure Stor
 
 1. Click the **Switch to the Azure AD User Account** link next to the **Authentication method** label.
 
+    > **Note**: You can see an error when you change the authentication method (the error is *"You do not have permissions to list the data using your user account with Azure AD"*). It is expected.  
+
     > **Note**: At this point, you no longer have access to the container.
 
 1. On the **az104-07-container** blade, click **Access Control (IAM)**.


### PR DESCRIPTION
- Lab 02a - Exercise 1 - Task 1 - Step 05
The portal ui allows user to add subscriptions to management group in the Subscriptions blade, not in the overview

- Lab02a - Exercise 01 - Cleanup - Step 08
The portal UI allows users to move subscriptions in the Subscriptions blade, not in the overview

- Lab 07 - Exercise 01 - Task 03 - Step 04
Remove "click on Upload" istruction. If the student click on Upload, the blob is uploaded in the container and the student need to select the file again. The student select the file, set the properties in the advanced section and then upload the blob.

- Lab 07 - Exercise 01 - Task 04 - Step 10
When the student change the Authentication Method, the portal returns an error in the blade. The students can be frustrated because the lab doesn't explain the error. The error is expected but the lab instruction doesn't mention this thing.