### PR TITLE
Update LAB_02b-Manage_Governance_via_Azure_Policy.md

### DIFF
--- a/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
+++ b/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
@@ -174,7 +174,7 @@ In this task, we will use a different policy definition to remediate any non-com
     | Setting | Value |
     | --- | --- |
     | Create a remediation task | enabled |
-    | Policy to remediate | **Inherit a tag from the subscription if missing** |
+    | Policy to remediate | **Inherit a tag from the resource group if missing** |
 
     >**Note**: This policy definition includes the **Modify** effect.
 


### PR DESCRIPTION
Changed type of "Policy to remediate" from "Inherit a tag from the subscription if missing" to "Inherit a tag from the resource group if missing" at the point 8 of the Task 3

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-