### PR TITLE
Autoscaling enabled by default.

### DIFF
--- a/Instructions/Labs/LAB_09c-Implement_Azure_Kubernetes_Service.md
+++ b/Instructions/Labs/LAB_09c-Implement_Azure_Kubernetes_Service.md
@@ -195,6 +195,7 @@ In this task, you will scale horizontally the number of pods and then number of 
     az aks scale --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --node-count 2
     ```
 
+    > **Note**: If you get this error `Cannot scale cluster autoscaler enabled node pool.` You need to disable the autoscaling on the agentpool overview.
     > **Note**: Wait for the provisioning of the additional node to complete. This might take about 3 minutes. If it fails, rerun the `az aks scale` command.
 
 1. From the **Cloud Shell** pane, run the following to verify the outcome of scaling the cluster:


### PR DESCRIPTION
Error while running this command " az aks scale --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --node-count 2"
Need to disable the autoscaling option to allow this command to run.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-