### PR TITLE
Update LAB_04-Implement_Virtual_Networking.md

### DIFF
--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -188,6 +188,10 @@ In this task, you will configure network security groups in order to allow for r
 
     >**Note**: This is expected, because public IP addresses of the Standard SKU, by default, require that the network interfaces to which they are assigned are protected by a network security group. In order to allow Remote Desktop connections, you will create a network security group explicitly allowing inbound RDP traffic from Internet and assign it to network interfaces of both virtual machines.
 
+1. Stop the **az104-04-vm0** and **az104-04-vm1** virtual machines.
+
+    >**Note**: This is done for lab expediency. If the virtual machines are running when a network security group is attached to their network interface, it can can take over 30 minutes for the attachment to take effect. Once the network security group has been created and attached, the virtual machines will be restarted, and the attachment will be in effect immediately.
+
 1. In the Azure portal, search for and select **Network security groups**, and, on the **Network security groups** blade, click **+ Create**.
 
 1. Create a network security group with the following settings (leave others with their default values):
@@ -224,6 +228,8 @@ In this task, you will configure network security groups in order to allow for r
 1. Associate the **az104-04-nsg01** network security group with the **az104-04-nic0** and **az104-04-nic1** network interfaces.
 
     >**Note**: It may take up to 5 minutes for the rules from the newly created Network Security Group to be applied to the Network Interface Card.
+
+1. Start the **az104-04-vm0** and **az104-04-vm1** virtual machines.
 
 1. Navigate back to the **az104-04-vm0** virtual machine blade.
 


### PR DESCRIPTION
Running Azure virtual machines don't properly pick up the NSG attachment to their NICs for a very long time (I waited over 30 minutes, and they still never properly implemented the rules).  I added two instructions, one to stop the VMs before creating and attaching the NSG, and a later one to start the VMs once the NSG has been attached.  This should give the desired student outcome w/o a very long wait.

# Module: 04
## Lab/Demo: 4

Fixes: 2

Changes proposed in this pull request:

In task 4, added a new step 4 (around line 191 and an explanatory note that tells the learner to stop the two running Azure virtual machines.

In task 4, added a new step 13 (around line 2302) that tells the learner to start the two Azure virtual machines.
-
-