### PR TITLE
Specify Region in Ex1 Task 1 Step 2

### DIFF
--- a/Instructions/Labs/LAB_03a-Manage_Azure_Resources_by_Using_the_Azure_Portal.md
+++ b/Instructions/Labs/LAB_03a-Manage_Azure_Resources_by_Using_the_Azure_Portal.md
@@ -42,7 +42,7 @@ In this task, you will use the Azure portal to create resource groups and create
     |Subscription| the name of the Azure subscription where you created the resource group |
     |Resource Group| the name of a new resource group **az104-03a-rg1** |
     |Disk name| **az104-03a-disk1** |
-    |Region| the name of the Azure region where you created the resource group |
+    |Region| **(US) East US** |
     |Availability zone| **None** |
     |Source type| **None** |
 


### PR DESCRIPTION
The instructions imply the resource group already exists, and so the learner could look up the region.  But it has not been created yet, so it needs to be specified in that step.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-