### PR TITLE
Fixes: RG name in note and field description

### DIFF
--- a/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
@@ -81,7 +81,7 @@ In this task, you will deploy four virtual machines into the same Azure region. 
 
     >**Note**: If you got an error stating the VM size is not available please ask your instructor for assistance and try these steps.
     > 1. Click on the `{}` button in your CloudShell, select the **az104-06-vms-loop-parameters.json** from the left hand side bar and take a note of the `vmSize` parameter value.
-    > 1. Check the location in which the 'az104-04-rg1' resource group is deployed. You can run `az group show -n az104-04-rg1 --query location` in your CloudShell to get it.
+    > 1. Check the location in which the 'az104-06-rg1' resource group is deployed. You can run `az group show -n az104-06-rg1 --query location` in your CloudShell to get it.
     > 1. Run `az vm list-skus --location <Replace with your location> -o table --query "[? contains(name,'Standard_D2s')].name"` in your CloudShell.
     > 1. Replace the value of `vmSize` parameter with one of the values returned by the command you just run. If there are no values returned, you may need to choose a different region to deploy into. You may also choose a different family name, like "Standard_B1s".
     > 1. Now redeploy your templates by running the `New-AzResourceGroupDeployment` command again. You can press the up button a few times which would bring the last executed command.
@@ -321,7 +321,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | Setting | Value |
     | --- | --- |
     | Route name | **az104-06-route-vnet2-to-vnet3** |
-    | Address prefix source | **IP Addresses** |
+    | Address prefix destination | **IP Addresses** |
     | Source IP addresses/CIDR ranges | **10.63.0.0/20** |
     | Next hop type | **Virtual appliance** |
     | Next hop address | **10.60.0.4** |
@@ -364,7 +364,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | Setting | Value |
     | --- | --- |
     | Route name | **az104-06-route-vnet3-to-vnet2** |
-    | Address prefix source | **IP Addresses** |
+    | Address prefix destination | **IP Addresses** |
     | Source IP addresses/CIDR ranges | **10.62.0.0/20** |    
     | Next hop type | **Virtual appliance** |
     | Next hop address | **10.60.0.4** |


### PR DESCRIPTION
# Module: 06
## Lab/Demo: 06

Fixes # .

Changes proposed in this pull request:
- Resource Group referenced in note on available VM sizes was from module 04. Someone must have copied/pasted the entire note.
- When adding a Route in a Route Table, the field is now called "Address prefix destination"