### PR TITLE
Fix Portal UI and Lab instructions incompatibilities

### DIFF
--- a/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
+++ b/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC.md
@@ -200,7 +200,7 @@ In this task, you will create an Azure Active Directory user, assign the RBAC ro
    
 1. Select **Refresh** to verify that the subscription has successfully moved to the **Tenant Root management group**.
 
-1. Navigate back to the **Management groups** blade, right click the **ellipsis** icon to the right of the **az104-02-mg1** management group and click **Delete**.
+1. Navigate back to the **Management groups** blade, click the **ellipsis** icon to the right of the **az104-02-mg1** management group and click **Delete**.
 
 #### Review
 

--- a/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
+++ b/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
@@ -144,7 +144,7 @@ In this task, we will use a different policy definition to remediate any non-com
 
 1. In the **Authoring** section, click **Assignments**. 
 
-1. In the list of assignments, right click the ellipsis icon in the row representing the **Require Role tag with Infra value** policy assignment and use the **Delete assignment** menu item to delete the assignment. 
+1. In the list of assignments, click the ellipsis icon in the row representing the **Require Role tag with Infra value** policy assignment and use the **Delete assignment** menu item to delete the assignment.
 
 1. Click **Assign policy** and specify the **Scope** by clicking the ellipsis button and selecting the following values:
 

--- a/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/Labs/LAB_06-Implement_Network_Traffic_Management.md
@@ -322,7 +322,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | --- | --- |
     | Route name | **az104-06-route-vnet2-to-vnet3** |
     | Address prefix destination | **IP Addresses** |
-    | Source IP addresses/CIDR ranges | **10.63.0.0/20** |
+    | Destination IP addresses/CIDR ranges | **10.63.0.0/20** |
     | Next hop type | **Virtual appliance** |
     | Next hop address | **10.60.0.4** |
 
@@ -365,7 +365,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | --- | --- |
     | Route name | **az104-06-route-vnet3-to-vnet2** |
     | Address prefix destination | **IP Addresses** |
-    | Source IP addresses/CIDR ranges | **10.62.0.0/20** |    
+    | Destination IP addresses/CIDR ranges | **10.62.0.0/20** |
     | Next hop type | **Virtual appliance** |
     | Next hop address | **10.60.0.4** |
 

--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -106,7 +106,7 @@ In this task, you will create and configure an Azure Storage account.
 
 1. Click **Next: Advanced >**, on the **Advanced** tab of the **Create storage account** blade, review the available options, accept the defaults, and click **Next: Networking >**.
 
-1. On the **Networking** tab of the **Create storage account** blade, review the available options, accept the default option **Public endpoint (all networks}** and click **Next: Data protection >**.
+1. On the **Networking** tab of the **Create storage account** blade, review the available options, accept the default option **Enable public access from all networks** and click **Next: Data protection >**.
 
 1. On the **Data protection** tab of the **Create storage account** blade, review the available options, accept the defaults, click **Review + Create**, wait for the validation process to complete and click **Create**.
 

--- a/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
+++ b/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
@@ -40,7 +40,7 @@ In this task, you will deploy Azure virtual machines into different availability
 
 1. Sign in to the [Azure portal](http://portal.azure.com).
 
-1. In the Azure portal, search for and select **Virtual machines** and, on the **Virtual machines** blade, click **+ Create**, click **+ Virtual machine**.
+1. In the Azure portal, search for and select **Virtual machines** and, on the **Virtual machines** blade, click **+ Create**, click **+ Azure virtual machine**.
 
 1. On the **Basics** tab of the **Create a virtual machine** blade, specify the following settings (leave others with their default values):
 

--- a/Instructions/Labs/LAB_09c-Implement_Azure_Kubernetes_Service.md
+++ b/Instructions/Labs/LAB_09c-Implement_Azure_Kubernetes_Service.md
@@ -173,11 +173,6 @@ In this task, you will scale horizontally the number of pods and then number of 
 1. From the **Cloud Shell** pane, and run the following to scale the deployment by increasing of the number of pods to 2:
 
     ```sh
-
-    RESOURCE_GROUP='az104-09c-rg1'
-
-    AKS_CLUSTER='az104-9c-aks1'
-
     kubectl scale --replicas=2 deployment/nginx-deployment
     ```
 
@@ -192,6 +187,10 @@ In this task, you will scale horizontally the number of pods and then number of 
 1. From the **Cloud Shell** pane, run the following to scale out the cluster by increasing the number of nodes to 2:
 
     ```sh
+    RESOURCE_GROUP='az104-09c-rg1'
+
+    AKS_CLUSTER='az104-9c-aks1'
+
     az aks scale --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --node-count 2
     ```
 


### PR DESCRIPTION
# Module: 02, 06, 07, 08, 09
## Lab/Demo: 2a, 2b, 6, 7, 8, 9c

Fixes # Inconsistencies with Azure Portal UI

Changes proposed in this pull request:

- Change `right click` to `click` in Portal UI in Lab 02
- Change `Source IP addresses/CIDR ranges` to `Destination IP addresses/CIDR ranges` in Lab 06 to match Portal UI
- Change `Public endpoint (all networks}` to `Enable public access from all networks` in Lab 07 to match Portal UI
- Change `+ Virtual machine` to `+ Azure virtual machine` in Lab 08 to match Portal UI
- Move two commands in bash scripts in Lab 09 to group them with their dependant command