### PR TITLE
Update LAB_04-Implement_Virtual_Networking.md

### DIFF
--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -172,7 +172,7 @@ In this task, you will configure static assignment of public and private IP addr
 
 1. Ensure the **Allocation** is **Static**.
 
-1. Select **Associate public IP address** and in the **Public IP address** drop-down select **az104-04-pip0**.
+1. Select **Associate public IP address** and in the **Public IP address** drop-down select **az104-04-pip01**.
 
 1. Select **Save**.
    


### PR DESCRIPTION
Instructions told to associate the same public IP twice, instead of using the second public IP. Typo, I guess...

# Module: 04
## Lab: 04

Fixes # .
Changed to the second PIP (az104-04-pip01) instead of the first (az104-04-pip0).