### PR TITLE
Fix incorrect case on diskSizeGB property

### DIFF
--- a/Instructions/Labs/LAB_03d-Manage_Azure_Resources_by_Using_Azure_CLI.md
+++ b/Instructions/Labs/LAB_03d-Manage_Azure_Resources_by_Using_Azure_CLI.md
@@ -95,7 +95,7 @@ In this task, you will managing configuration of the Azure managed disk by using
 1. To verify that the change took effect, run the following:
 
    ```sh
-   az disk show --resource-group $RGNAME --name $DISKNAME --query diskSizeGb
+   az disk show --resource-group $RGNAME --name $DISKNAME --query diskSizeGB
    ```
 
 1. To change the disk performance SKU to **Premium_LRS**, from the Bash session within Cloud Shell, run the following:


### PR DESCRIPTION
# Module: Administer Azure Resources
## Lab/Demo: 03d

Fixes # .

Changes proposed in this pull request:

Change this:
az disk show --resource-group $RGNAME --name $DISKNAME --query diskSizeGb

To this:
az disk show --resource-group $RGNAME --name $DISKNAME --query diskSizeGB

Properties on a query are case-sensitive. The existed incorrect case diskSizeGb returns no value whereas the correct case diskSizeGB returns the disk size int which is 64 in this example.