### PR TITLE
rename 'az group deployment' (deprecated) to 'az deployment group' in lab 03

### DIFF
--- a/New Instructions/Lab/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/New Instructions/Lab/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -234,7 +234,7 @@ In this task, you will use a Bicep file to deploy a managed disk. Bicep is a dec
 1. Now, deploy the template.
 
     ```
-    az group deployment create --resource-group az104-rg3 --template-file azuredeploydisk.bicep
+    az deployment group create --resource-group az104-rg3 --template-file azuredeploydisk.bicep
     ```
 
 1. Confirm the disk was created.


### PR DESCRIPTION
# Module: Administer Azure Resources
## Lab/Demo: 03b

Changes proposed in this pull request:

```
$ az group deployment create --resource-group my-rg --template-file ./azuredeploydisk.bicep
This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.
```