### PR TITLE
Update Lab 10 az104-10-vms-edge-template.json

### DIFF
--- a/Allfiles/Labs/10/az104-10-vms-edge-template.json
+++ b/Allfiles/Labs/10/az104-10-vms-edge-template.json
@@ -183,8 +183,11 @@
         "count": "[variables('numberOfInstances')]"
       },
       "location": "[resourceGroup().location]",
+      "sku": {
+        "name":"Standard"
+      },
       "properties": {
-        "publicIpAllocationMethod": "Dynamic"
+        "publicIpAllocationMethod": "Static"
       }
     },
     {


### PR DESCRIPTION
…

# Module: 10
## Lab/Demo: 10

Fixes # .

Changes proposed in this pull request:

Basic IPv4 SKU Public IP Addresses no longer available in certain regions and will retire on 30th September 2025 entirely. Thus, change to Standard SKU which only allows Static as allocation method
-
-
-