### PR TITLE
Update LAB_09a UI update

### DIFF
--- a/Instructions/Labs/LAB_09a-Implement_Web_Apps.md
+++ b/Instructions/Labs/LAB_09a-Implement_Web_Apps.md
@@ -138,9 +138,9 @@ In this task, you will swap the staging slot with the production slot. Swapping 
 
 In this task, you will configure autoscaling of Azure Web App. Autoscaling enables you to maintain optimal performance for your web app when traffic to the web app increases. To determine when the app should scale you can monitor metrics like CPU usage, memory, or bandwidth.
 
-1. In the **Settings** section, select **Scale out (App Service plan)**.
+1. In the left pane, in the **App Service plan** section, select **Scale out**.
 
-    >**Note:** Ensure you are working on the production slot not the staging slot.  
+    >**Note:** Ensure you are working on the production slot, not the staging slot.  
 
 1. From the **Scaling** section, select **Automatic**. Notice the **Rules Based** option. Rules based scaling can be configured for different app metrics. 
 


### PR DESCRIPTION
Scale out is now under the App Service plan section, not Settings.

# Module: 09
## Lab: 09a

Fixes #1009

Changes proposed in this pull request:

- Scale out moved to App Service plan from Settings
