### PR TITLE
Modify subnet address prefixes in template

### DIFF
--- a/Allfiles/Labs/04/az104-04-template.json
+++ b/Allfiles/Labs/04/az104-04-template.json
@@ -30,7 +30,7 @@
                         "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworks_ManufacturingVnet_name'), 'SensorSubnet1')]",
                         "properties": {
                             "addressPrefixes": [
-                                "10.30.10.0/24"
+                                "10.30.20.0/24"
                             ],
                             "delegations": [],
                             "privateEndpointNetworkPolicies": "Disabled",
@@ -44,7 +44,7 @@
                         "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworks_ManufacturingVnet_name'), 'SensorSubnet2')]",
                         "properties": {
                             "addressPrefixes": [
-                                "10.30.20.0/24"
+                                "10.30.21.0/24"
                             ],
                             "delegations": [],
                             "privateEndpointNetworkPolicies": "Disabled",
@@ -67,7 +67,7 @@
             ],
             "properties": {
                 "addressPrefixes": [
-                    "10.30.10.0/24"
+                    "10.30.20.0/24"
                 ],
                 "delegations": [],
                 "privateEndpointNetworkPolicies": "Disabled",
@@ -84,7 +84,7 @@
             ],
             "properties": {
                 "addressPrefixes": [
-                    "10.30.20.0/24"
+                    "10.30.21.0/24"
                 ],
                 "delegations": [],
                 "privateEndpointNetworkPolicies": "Disabled",
@@ -94,3 +94,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
# Module: 04
## Lab/Demo: 04

Fixes # .

Changes proposed in this pull request:

Updated subnet address prefixes for SensorSubnet1 and SensorSubnet2.

As in instructions:
- `SharedServicesSubnet` -> `SensorSubnet1`, 10.30.20.0/24.
- `DatabaseSubnet` -> `SensorSubnet2`, 10.30.21.0/24.
