### PR TITLE
Fix syntax error in AZ CLI command

### DIFF
--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -234,7 +234,7 @@ In this task, you will use a Bicep file to deploy a managed disk. Bicep is a dec
 1. Confirm the disk was created.
 
     ```sh
-    az disk list --output table
+    az disk list --resource-group az104-rg3 --output table
     ```
 
     >**Note:** You have successfully deployed five managed disks, each in a different way. Nice job!


### PR DESCRIPTION
Specify resource group in disk list command, required parameter

# Module: 00
## Lab/Demo: 3

Changes proposed in this pull request:
add missing mandatory parameter to AZ CLI command
-
-
-