### PR TITLE
Update lab instructions for RBAC and management groups

### DIFF
--- a/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC_Entra.md
+++ b/Instructions/Labs/LAB_02a_Manage_Subscriptions_and_RBAC_Entra.md
@@ -67,7 +67,7 @@ In this task, you will create and configure management groups. Management groups
 
 In this task, you will review the built-in roles and assign the VM Contributor role to a member of the Help Desk. Azure provides a large number of [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles). 
 
-    >**Note:** The next step assigns the role to the **helpdesk** group. If you do not have a Help Desk group, take a minute to create it.
+    >**Note:** In the following steps, you will assign the role to the **helpdesk** group. If you do not have a Help Desk group, take a minute to create it.
 
 1. Select the **az104-mg1** management group.
 


### PR DESCRIPTION
This step goes before opening the blade.

# Module: 02
## Lab/Demo: 02a

Changes proposed in this pull request:
This pull request makes a minor clarification to the lab instructions for assigning the VM Contributor role to the Help Desk group. The note about creating the Help Desk group has been moved to appear before the relevant step for better clarity. No functional changes were made to the lab content.