### PR TITLE
fix: update demo 03 administer azure resource to use update quickstart template

### DIFF
--- a/Instructions/Demos/03 - Administer Azure Resources.md
+++ b/Instructions/Demos/03 - Administer Azure Resources.md
@@ -93,7 +93,7 @@ In this demonstration, we explore QuickStart templates.
 
 1. Start by browsing to the [Azure Quickstart Templates gallery](https://learn.microsoft.com/en-us/samples/browse/?expanded=azure&products=azure-resource-manager). Notice there are JSON and Bicep examples. 
 
-1. Ask students if there are any specific templates that are of interest. If not, select a template. For example, the [Deploy a simple Windows VM with tags](https://learn.microsoft.com/en-us/samples/azure/azure-quickstart-templates/vm-tags/) template.
+1. Ask students if there are any specific templates that are of interest. If not, select a template. For example, the [Deploy a simple Windows VM with tags](https://learn.microsoft.com/en-us/samples/azure/azure-quickstart-templates/vm-simple-windows/) template.
 
 1. Discuss how the **Deploy to Azure** button enables you to deploy the template directly through the Azure portal.
 


### PR DESCRIPTION
fix: update demo 03 administer azure resource to use update quickstart template

# Module: 03
## Lab/Demo: 03

Fixes # .
The demo 03 is point to a old quickstarter template that uses Public IP Address type Basic that was deprecated on Azure.

Changes proposed in this pull request:

- Use a new quickstarter template