### PR TITLE
Update VM creation instructions for clarity

### DIFF
--- a/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
+++ b/Instructions/Labs/LAB_08-Manage_Virtual_Machines.md
@@ -331,7 +331,7 @@ In this task, you scale the virtual machine scale set using a custom scale rule.
 
 1. Be sure to select **PowerShell**. If necessary, configure the shell storage.
 
-1. Run the following command to create a virtual machine. When prompted, provide a username and password for the VM. While you wait check out the [New-AzVM](https://learn.microsoft.com/powershell/module/az.compute/new-azvm?view=azps-11.1.0) command reference for all the parameters associated with creating a virtual machine.
+1. Run the following command to create a virtual machine. When prompted, provide a username and password to create the local administrator account on the VM. While you wait check out the [New-AzVM](https://learn.microsoft.com/powershell/module/az.compute/new-azvm?view=azps-11.1.0) command reference for all the parameters associated with creating a virtual machine.
 
     ```powershell
     New-AzVm `
@@ -372,7 +372,7 @@ In this task, you scale the virtual machine scale set using a custom scale rule.
 
 1. Be sure to select **Bash**. If necessary, configure the shell storage.
 
-1. Run the following command to create a virtual machine. When prompted, provide a username and password for the VM. While you wait check out the [az vm create](https://learn.microsoft.com/cli/azure/vm?view=azure-cli-latest#az-vm-create) command reference for all the parameters associated with creating a virtual machine.
+1. Run the following command to create a virtual machine. While you wait check out the [az vm create](https://learn.microsoft.com/cli/azure/vm?view=azure-cli-latest#az-vm-create) command reference for all the parameters associated with creating a virtual machine.
 
     ```sh
     az vm create --name myCLIVM --resource-group az104-rg8 --image Ubuntu2204 --admin-username localadmin --generate-ssh-keys


### PR DESCRIPTION
In Task 5, students are often confused about the prompt for credentials and enter the lab user account and password (creates an error). 
In Task 6, there is no prompt for credentials in the CLI command. 

# Module: 08
## Lab: 08
### Task 5 & 6

Fixes #1050.

Changes proposed in this pull request:

- Clarified instructions for creating a VM by specifying that the username and password are for the local administrator account.
- Removed the instruction about providing a username and password with the CLI command.