### PR TITLE
Clarify Cloud Shell usage and improve Azure resource lab instructions

### DIFF
--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -83,8 +83,6 @@ In this task, you use the downloaded template to deploy a new managed disk. This
 
 1. In the Azure portal, search for and select `Deploy a custom template`.
 
-1. If a banner appears at the top of the page promoting Deployment Stacks, disregard it. 
-
 1. On the **Custom deployment** blade, notice there is the ability to use a **Quickstart template**. There are many built-in templates as shown in the drop-down menu. 
 
 1. Instead of using a Quickstart, select **Build your own template in the editor**.
@@ -141,10 +139,6 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
     >**Did you know?**  If you mostly work with Linux systems, Bash (CLI) feels more familiar. If you mostly work with Windows systems, Azure PowerShell feels more familiar. 
 
-1. Once Cloud Shell opens, select **Settings > Go to Classic version**.
-
-1. After switching, select **Settings > Reset user settings**, then confirm to trigger the **Getting Started** wizard.
-
 1. On the **Getting started** screen select **Mount storage account**, select your **Storage account subscription**, and then select **Apply**.
 
 1. Select **I want to create a storage account** and then **Next**. Complete the **Create storage account** information. 
@@ -159,6 +153,8 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 1. When completed select **Create**.
 
     >It will take a couple of minutes to provision the storage.
+
+1. Select **Settings** (top bar) and then **Go to classic version**.
 
 1. Select the **Upload/Download files** icon (top bar) and then select **Upload**.
 

--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -83,6 +83,8 @@ In this task, you use the downloaded template to deploy a new managed disk. This
 
 1. In the Azure portal, search for and select `Deploy a custom template`.
 
+1. If a banner appears at the top of the page promoting Deployment Stacks, disregard it. 
+
 1. On the **Custom deployment** blade, notice there is the ability to use a **Quickstart template**. There are many built-in templates as shown in the drop-down menu. 
 
 1. Instead of using a Quickstart, select **Build your own template in the editor**.
@@ -139,6 +141,10 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
     >**Did you know?**  If you mostly work with Linux systems, Bash (CLI) feels more familiar. If you mostly work with Windows systems, Azure PowerShell feels more familiar. 
 
+1. Once Cloud Shell opens, select **Settings > Go to Classic version**.
+
+1. After switching, select **Settings > Reset user settings**, then confirm to trigger the **Getting Started** wizard.
+
 1. On the **Getting started** screen select **Mount storage account**, select your **Storage account subscription**, and then select **Apply**.
 
 1. Select **I want to create a storage account** and then **Next**. Complete the **Create storage account** information. 
@@ -153,8 +159,6 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 1. When completed select **Create**.
 
     >It will take a couple of minutes to provision the storage.
-
-1. Select **Settings** (top bar) and then **Go to classic version**.
 
 1. Select the **Upload/Download files** icon (top bar) and then select **Upload**.
 
@@ -182,6 +186,13 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 ## Task 4: Deploy a template with the CLI 
 
 1. Continue in the **Cloud Shell** select **Bash**. **Confirm** your choice.
+
+1. If you have multiple subscriptions, first ensure the correct subscription context is set by running `az account show` to confirm the active subscription. If it does not match the subscription containing **az104-rg3**, run `az account set --subscription <your-subscription-id>` before proceeding. This is especially important when Cloud Shell is running in ephemeral mode, as switching from PowerShell to Bash may reset the subscription context.
+
+    ```sh
+    az account show
+    az account set --subscription <your-subscription-id>
+    ```
 
 1. Verify your files are available in the Cloud Shell storage. If you completed the previous task your template files should be available. 
 
@@ -251,7 +262,7 @@ In this task, you will use a Bicep file to deploy a managed disk. Bicep is a dec
 
 If you are working with **your own subscription** take a minute to delete the lab resources. This will ensure resources are freed up and cost is minimized. The easiest way to delete the lab resources is to delete the lab resource group. 
 
-+ In the Azure portal, select the resource group, select **Delete the resource group**, **Enter resource group name**, and then click **Delete**.
++ In the Azure portal, select the resource group, select **Delete the resource group**, **Enter resource group name**, and then click **Delete**. When the confirmation dialog appears stating that deleting the resource group is permanent and cannot be undone, click **Delete** again to complete the deletion.
 + Using Azure PowerShell, `Remove-AzResourceGroup -Name resourceGroupName`.
 + Using the CLI, `az group delete --name resourceGroupName`.
 

--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -160,6 +160,10 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
     >It will take a couple of minutes to provision the storage.
 
+    >**Note:** Once Cloud Shell opens, if it is running in **Bash**, use the **Shell** dropdown in the toolbar to switch to **PowerShell** and confirm the switch when prompted.
+
+    >**Note:** If you see a warning message stating *Failed to mount the Azure file share. Your cloud drive won't be available. Your Cloud Shell session will be ephemeral*, you can safely disregard it — Cloud Shell will still be fully functional in PowerShell mode.
+
 1. Select the **Upload/Download files** icon (top bar) and then select **Upload**.
 
 1. Upload both the template and parameters files from the **Downloads** directory. 
@@ -187,7 +191,7 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
 1. Continue in the **Cloud Shell** select **Bash**. **Confirm** your choice.
 
-1. If you have multiple subscriptions, first ensure the correct subscription context is set by running `az account show` to confirm the active subscription. If it does not match the subscription containing **az104-rg3**, run `az account set --subscription <your-subscription-id>` before proceeding. This is especially important when Cloud Shell is running in ephemeral mode, as switching from PowerShell to Bash may reset the subscription context.
+1. If you have multiple subscriptions, first ensure the correct subscription context is set by running `az account show` to confirm the active subscription. The default subscription may be set to one that does not contain **az104-rg3** — if so, switch to the correct subscription with `az account set --subscription <your-subscription-id>`, then confirm the change by running `az account show` again. This is especially important when Cloud Shell is running in ephemeral mode, as switching from PowerShell to Bash may reset the subscription context.
 
     ```sh
     az account show

--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -160,10 +160,6 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
     >It will take a couple of minutes to provision the storage.
 
-    >**Note:** Once Cloud Shell opens, if it is running in **Bash**, use the **Shell** dropdown in the toolbar to switch to **PowerShell** and confirm the switch when prompted.
-
-    >**Note:** If you see a warning message stating *Failed to mount the Azure file share. Your cloud drive won't be available. Your Cloud Shell session will be ephemeral*, you can safely disregard it — Cloud Shell will still be fully functional in PowerShell mode.
-
 1. Select the **Upload/Download files** icon (top bar) and then select **Upload**.
 
 1. Upload both the template and parameters files from the **Downloads** directory. 
@@ -191,7 +187,7 @@ In this task, you work with the Azure Cloud Shell and Azure PowerShell. Azure Cl
 
 1. Continue in the **Cloud Shell** select **Bash**. **Confirm** your choice.
 
-1. If you have multiple subscriptions, first ensure the correct subscription context is set by running `az account show` to confirm the active subscription. The default subscription may be set to one that does not contain **az104-rg3** — if so, switch to the correct subscription with `az account set --subscription <your-subscription-id>`, then confirm the change by running `az account show` again. This is especially important when Cloud Shell is running in ephemeral mode, as switching from PowerShell to Bash may reset the subscription context.
+1. If you have multiple subscriptions, first ensure the correct subscription context is set by running `az account show` to confirm the active subscription. If it does not match the subscription containing **az104-rg3**, run `az account set --subscription <your-subscription-id>` before proceeding. This is especially important when Cloud Shell is running in ephemeral mode, as switching from PowerShell to Bash may reset the subscription context.
 
     ```sh
     az account show

--- a/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
+++ b/Instructions/Labs/LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md
@@ -63,6 +63,8 @@ In this task, we will create a managed disk in the Azure portal. Managed disks a
 
     >**Note:** We are creating a simple managed disk so you can practice with templates. Azure managed disks are block-level storage volumes that are managed by Azure.
 
+    >**Note:** If deployment fails due to capacity or quota limits, adjust the configuration or choose a different region.
+
 1. Click **Review + Create** then select **Create**.
 
 1. Monitor the notifications (upper right) and after the deployment select **Go to resource**. 

--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -97,7 +97,7 @@ The organization plans a large amount of growth for core services. In this task,
 
 1. In the **Automation** section, select **Export template**, and then wait for the template to be generated.
 
-1. On the **ARM template** tab, ensure the **Include parameters** checkbox is selected, then click **Download**. Confirm **template.json** and **parameters.json** are both in your **Downloads** folder.
+1. Select the **Template** tab and **Download** the template. Then, switch to the **Parameters** tab, and repeat the **Download** operation.
 
 1. Navigate on the local machine to the **Downloads** folder. 
 

--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -64,6 +64,8 @@ The organization plans a large amount of growth for core services. In this task,
 	| Name               | `CoreServicesVnet`     |
 	| Region             | (US) **East US**         |
 
+    >**Note:** If deployment fails due to capacity or quota limits, adjust the configuration or choose a different region.
+
 1. Move to the **Address space** tab.
 
 	|  **Option**         | **Value**            |

--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -107,30 +107,39 @@ In this task, you create the ManufacturingVnet virtual network and associated su
 
 1. Locate the **template.json** file exported in the previous task. It should be in your **Downloads** folder.
 
-1. Open a **PowerShell** window. Run the following commands to update **template.json** from the Downloads folder:
+1. Edit the file using the editor of your choice. Many editors have a *change all occurrences* feature. If you are using Visual Studio Code be sure you are working in a **trusted window** and not in the **restricted mode**. Consult the architecture diagram to verify the details. 
 
-    ```powershell
-    $content = Get-Content "$env:USERPROFILE\Downloads\template.json" -Raw
-    $content = $content -replace 'CoreServicesVnet', 'ManufacturingVnet'
-    $content = $content -replace '10\.20\.0\.0', '10.30.0.0'
-    $content = $content -replace 'SharedServicesSubnet', 'SensorSubnet1'
-    $content = $content -replace '10\.20\.10\.0/24', '10.30.20.0/24'
-    $content = $content -replace 'DatabaseSubnet', 'SensorSubnet2'
-    $content = $content -replace '10\.20\.20\.0/24', '10.30.21.0/24'
-    $content | Set-Content "$env:USERPROFILE\Downloads\template.json"
-    ```
+### Make changes for the ManufacturingVnet virtual network
 
-1. Then run the following commands to update **parameters.json**:
+1. Replace all occurrences of **CoreServicesVnet** with `ManufacturingVnet`. 
 
-    ```powershell
-    $content = Get-Content "$env:USERPROFILE\Downloads\parameters.json" -Raw
-    $content = $content -replace 'CoreServicesVnet', 'ManufacturingVnet'
-    $content | Set-Content "$env:USERPROFILE\Downloads\parameters.json"
-    ```
+1. Replace all occurrences of **10.20.0.0** with `10.30.0.0`. 
 
-1. Both files are now saved with the required replacements applied. Read back through the files and ensure everything looks correct. Use the architecture diagram for resource names and IP addresses.
+### Make changes for the ManufacturingVnet subnets
+
+1. Change all occurrences of **SharedServicesSubnet** to `SensorSubnet1`.
+
+1. Change all occurrences of **10.20.10.0/24** to `10.30.20.0/24`.
+
+1. Change all occurrences of **DatabaseSubnet** to `SensorSubnet2`.
+
+1. Change all occurrences of **10.20.20.0/24** to `10.30.21.0/24`.
+
+1. Read back through the file and ensure everything looks correct. Use the architecture diagram for resource names and IP addresses. 
+
+1. Be sure to **Save** your changes.
 
 >**Note:** There are completed template files in the lab files directory. 
+
+### Make changes to the parameters file
+
+1. Locate the **parameters.json** file exported in the previous task. It should be in your **Downloads** folder.
+
+1. Edit the file using the editor of your choice.
+
+1. Replace the one occurrence of **CoreServicesVnet** with `ManufacturingVnet`.
+
+1. **Save** your changes.
    
 ### Deploy the custom template
 
@@ -199,8 +208,6 @@ In this task, we create an Application Security Group and a Network Security Gro
     | Virtual network | **CoreServicesVnet (az104-rg4)** |
     | Subnet | **SharedServicesSubnet** |
 
-    >**Note:** Verify that **Virtual network** is set to **CoreServicesVnet (az104-rg4)** and **Subnet** is set to **SharedServicesSubnet** — these fields may already be pre-populated.
-
 1. Click **OK** to save the association.
 
 ### Configure an inbound security rule to allow ASG traffic
@@ -216,11 +223,11 @@ In this task, we create an Application Security Group and a Network Security Gro
     | Setting | Value |
     | -- | -- |
     | Source | **Application security group** |
-    | Source application security groups | **asg-web** (use the filter textbox to locate it; ASGs are grouped by resource group) |
+    | Source application security groups | **asg-web** |
     | Source port ranges |  * |
     | Destination | **Any** |
     | Service | **Custom** (notice your other choices) |
-    | Destination port ranges | clear any default value (such as `8080`) and enter **80,443** |
+    | Destination port ranges | **80,443** |
     | Protocol | **TCP** |
     | Action | **Allow** |
     | Priority | **100** |
@@ -313,8 +320,6 @@ A private DNS zone provides name resolution services within virtual networks. A 
     | Name | `private.contoso.com` (adjust if you had to rename) |
     | Region |**East US** |
 
-    >**Note:** The location is automatically set to the resource group location and the private DNS zone resource will be created as **Global**.
-
 1. Select **Review + create** and then **Create**.
    
 1. Wait for the DNS zone to deploy and then select **Go to resource**.
@@ -328,9 +333,7 @@ A private DNS zone provides name resolution services within virtual networks. A 
     | Link name | `manufacturing-link` |
     | Virtual network | `ManufacturingVnet` |
 
-    >**Note:** In the **Configuration** section, leave **Enable auto registration** and **Enable fallback to internet** at their default settings.
-
-1. Select **Create** and wait for the link to create. After the link is created, click **Refresh** to see the new link appear in the grid.
+1. Select **Create** and wait for the link to create. 
 
 1. From the **DNS Management** blade select **+ Recordsets**. You would now add a record for each virtual machine that needs private name-resolution support.
 

--- a/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
+++ b/Instructions/Labs/LAB_04-Implement_Virtual_Networking.md
@@ -64,7 +64,7 @@ The organization plans a large amount of growth for core services. In this task,
 	| Name               | `CoreServicesVnet`     |
 	| Region             | (US) **East US**         |
 
-1. Move to the **IP Addresses** tab.
+1. Move to the **Address space** tab.
 
 	|  **Option**         | **Value**            |
 	| ------------------ | -------------------- |
@@ -95,7 +95,7 @@ The organization plans a large amount of growth for core services. In this task,
 
 1. In the **Automation** section, select **Export template**, and then wait for the template to be generated.
 
-1. Select the **Template** tab and **Download** the template. Then, switch to the **Parameters** tab, and repeat the **Download** operation.
+1. On the **ARM template** tab, ensure the **Include parameters** checkbox is selected, then click **Download**. Confirm **template.json** and **parameters.json** are both in your **Downloads** folder.
 
 1. Navigate on the local machine to the **Downloads** folder. 
 
@@ -107,39 +107,30 @@ In this task, you create the ManufacturingVnet virtual network and associated su
 
 1. Locate the **template.json** file exported in the previous task. It should be in your **Downloads** folder.
 
-1. Edit the file using the editor of your choice. Many editors have a *change all occurrences* feature. If you are using Visual Studio Code be sure you are working in a **trusted window** and not in the **restricted mode**. Consult the architecture diagram to verify the details. 
+1. Open a **PowerShell** window. Run the following commands to update **template.json** from the Downloads folder:
 
-### Make changes for the ManufacturingVnet virtual network
+    ```powershell
+    $content = Get-Content "$env:USERPROFILE\Downloads\template.json" -Raw
+    $content = $content -replace 'CoreServicesVnet', 'ManufacturingVnet'
+    $content = $content -replace '10\.20\.0\.0', '10.30.0.0'
+    $content = $content -replace 'SharedServicesSubnet', 'SensorSubnet1'
+    $content = $content -replace '10\.20\.10\.0/24', '10.30.20.0/24'
+    $content = $content -replace 'DatabaseSubnet', 'SensorSubnet2'
+    $content = $content -replace '10\.20\.20\.0/24', '10.30.21.0/24'
+    $content | Set-Content "$env:USERPROFILE\Downloads\template.json"
+    ```
 
-1. Replace all occurrences of **CoreServicesVnet** with `ManufacturingVnet`. 
+1. Then run the following commands to update **parameters.json**:
 
-1. Replace all occurrences of **10.20.0.0** with `10.30.0.0`. 
+    ```powershell
+    $content = Get-Content "$env:USERPROFILE\Downloads\parameters.json" -Raw
+    $content = $content -replace 'CoreServicesVnet', 'ManufacturingVnet'
+    $content | Set-Content "$env:USERPROFILE\Downloads\parameters.json"
+    ```
 
-### Make changes for the ManufacturingVnet subnets
-
-1. Change all occurrences of **SharedServicesSubnet** to `SensorSubnet1`.
-
-1. Change all occurrences of **10.20.10.0/24** to `10.30.20.0/24`.
-
-1. Change all occurrences of **DatabaseSubnet** to `SensorSubnet2`.
-
-1. Change all occurrences of **10.20.20.0/24** to `10.30.21.0/24`.
-
-1. Read back through the file and ensure everything looks correct. Use the architecture diagram for resource names and IP addresses. 
-
-1. Be sure to **Save** your changes.
+1. Both files are now saved with the required replacements applied. Read back through the files and ensure everything looks correct. Use the architecture diagram for resource names and IP addresses.
 
 >**Note:** There are completed template files in the lab files directory. 
-
-### Make changes to the parameters file
-
-1. Locate the **parameters.json** file exported in the previous task. It should be in your **Downloads** folder.
-
-1. Edit the file using the editor of your choice.
-
-1. Replace the one occurrence of **CoreServicesVnet** with `ManufacturingVnet`.
-
-1. **Save** your changes.
    
 ### Deploy the custom template
 
@@ -208,6 +199,8 @@ In this task, we create an Application Security Group and a Network Security Gro
     | Virtual network | **CoreServicesVnet (az104-rg4)** |
     | Subnet | **SharedServicesSubnet** |
 
+    >**Note:** Verify that **Virtual network** is set to **CoreServicesVnet (az104-rg4)** and **Subnet** is set to **SharedServicesSubnet** — these fields may already be pre-populated.
+
 1. Click **OK** to save the association.
 
 ### Configure an inbound security rule to allow ASG traffic
@@ -223,11 +216,11 @@ In this task, we create an Application Security Group and a Network Security Gro
     | Setting | Value |
     | -- | -- |
     | Source | **Application security group** |
-    | Source application security groups | **asg-web** |
+    | Source application security groups | **asg-web** (use the filter textbox to locate it; ASGs are grouped by resource group) |
     | Source port ranges |  * |
     | Destination | **Any** |
     | Service | **Custom** (notice your other choices) |
-    | Destination port ranges | **80,443** |
+    | Destination port ranges | clear any default value (such as `8080`) and enter **80,443** |
     | Protocol | **TCP** |
     | Action | **Allow** |
     | Priority | **100** |
@@ -273,7 +266,7 @@ You can configure Azure DNS to resolve host names in your public domain. For exa
     |:---------|:---------|
     | Subscription | **Select your subscription** |
     | Resource group | **az104-rg4** |
-    | Name | `contoso.com` (if reserved adjust the name) |
+    | Name | `contosoxyz104.com` (if reserved adjust the name) |
     | Region |**East US** (review the informational icon) |
 
 1. Select **Review + create** and then **Create**.
@@ -288,6 +281,7 @@ You can configure Azure DNS to resolve host names in your public domain. For exa
     |:---------|:---------|
     | Name | **www** |
     | Type | **A** |
+    | Alias record set | **No** |
     | TTL | **1** |
     | IP address | **10.1.1.4** |
 
@@ -298,9 +292,9 @@ You can configure Azure DNS to resolve host names in your public domain. For exa
 1. Open a command prompt, and run the following command. If you have changed the domain name, make an adjustment. 
 
    ```sh
-   nslookup www.contoso.com <name server name you copied in step 6 above>
+   nslookup www.contosoxyz104.com <name server name you copied in step 6 above>
    ```
-1. Verify the host name www.contoso.com resolves to the IP address you provided. This confirms name resolution is working correctly.
+1. Verify the host name www.contosoxyz104.com resolves to the IP address you provided. This confirms name resolution is working correctly.
 
 ### Configure a private DNS zone
 
@@ -319,6 +313,8 @@ A private DNS zone provides name resolution services within virtual networks. A 
     | Name | `private.contoso.com` (adjust if you had to rename) |
     | Region |**East US** |
 
+    >**Note:** The location is automatically set to the resource group location and the private DNS zone resource will be created as **Global**.
+
 1. Select **Review + create** and then **Create**.
    
 1. Wait for the DNS zone to deploy and then select **Go to resource**.
@@ -332,7 +328,9 @@ A private DNS zone provides name resolution services within virtual networks. A 
     | Link name | `manufacturing-link` |
     | Virtual network | `ManufacturingVnet` |
 
-1. Select **Create** and wait for the link to create. 
+    >**Note:** In the **Configuration** section, leave **Enable auto registration** and **Enable fallback to internet** at their default settings.
+
+1. Select **Create** and wait for the link to create. After the link is created, click **Refresh** to see the new link appear in the grid.
 
 1. From the **DNS Management** blade select **+ Recordsets**. You would now add a record for each virtual machine that needs private name-resolution support.
 

--- a/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
+++ b/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
@@ -201,7 +201,13 @@ In this task, you retest the connection between the virtual machines in differen
 
 >**Did you know?** There are many ways to check connections. In this task, you use **Run command**. You could also continue to use Network Watcher. Or you could use a [Remote Desktop Connection](https://learn.microsoft.com/azure/virtual-machines/windows/connect-rdp#connect-to-the-virtual-machine) to the access the virtual machine. Once connected, use **test-connection**. As you have time, give RDP a try. 
 
-1. Switch to the `ManufacturingVM` virtual machine.
+1. Switch to the `CoreServicesVM` virtual machine. In the **Operations** blade, select **Run command**, then select **RunPowerShellScript**. Run the following command to enable the Windows Firewall rule that allows inbound RDP traffic:
+
+    ```Powershell
+    Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+    ```
+
+1. Wait for the script to complete, then switch to the `ManufacturingVM` virtual machine.
 
 1. In the **Operations** blade, select the **Run command** blade.
 
@@ -228,10 +234,11 @@ In this task, you want to control network traffic between the perimeter subnet a
     | Setting | Value | 
     | --- | --- |
     | Name | `perimeter` |
-    | Starting address | `10.0.1.0/24`  |
+    | Starting address | `10.0.1.0`  |
+    | Size | `/24` |
 
    
-1. In the Azure portal, search for and select `Route tables`, select **+ Create**.
+1. In the Azure portal, search for and select `Route tables` to open the **Network foundation | Route tables** page, then select **Create**.
 
 1. Enter the following details, select **Review + create**, and then select **Create**. 
 
@@ -272,7 +279,7 @@ In this task, you want to control network traffic between the perimeter subnet a
 
 If you are working with **your own subscription** take a minute to delete the lab resources. This will ensure resources are freed up and cost is minimized. The easiest way to delete the lab resources is to delete the lab resource group. 
 
-+ In the Azure portal, select the resource group, select **Delete the resource group**, **Enter resource group name**, and then click **Delete**.
++ In the Azure portal, select the resource group, select **Delete the resource group**, **Enter resource group name**, and then click **Delete**. When the **Delete confirmation** dialog appears stating that deleting the resource group is permanent and cannot be undone, click **Delete** again to complete the deletion.
 + Using Azure PowerShell, `Remove-AzResourceGroup -Name resourceGroupName`.
 + Using the CLI, `az group delete --name resourceGroupName`.
 

--- a/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
+++ b/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
@@ -234,11 +234,10 @@ In this task, you want to control network traffic between the perimeter subnet a
     | Setting | Value | 
     | --- | --- |
     | Name | `perimeter` |
-    | Starting address | `10.0.1.0`  |
-    | Size | `/24` |
+    | Starting address | `10.0.1.0/24`  |
 
    
-1. In the Azure portal, search for and select `Route tables` to open the **Network foundation | Route tables** page, then select **Create**.
+1. In the Azure portal, search for and select `Route tables`, select **+ Create**.
 
 1. Enter the following details, select **Review + create**, and then select **Create**. 
 

--- a/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
+++ b/Instructions/Labs/LAB_05-Implement_Intersite_Connectivity.md
@@ -114,6 +114,8 @@ In this task, you create a manufacturing services virtual network with a virtual
     | Password | **Provide a complex password** |
     | Public inbound ports | **None** |
 
+    >**Note:** If deployment fails due to capacity or quota limits, adjust the configuration or choose a different region.
+
 1. On the **Disks** tab take the defaults and then select **Next : Networking >**.
 
 1. On the Networking tab, for Virtual network, select **Create new**.


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-
This pull request updates several Azure lab instructions to improve clarity, address common deployment issues, and ensure consistency in resource naming and cleanup steps. The most significant changes focus on adding troubleshooting notes for quota/capacity errors, clarifying subscription context in Cloud Shell, updating DNS naming conventions, and providing more explicit deletion instructions.

**Deployment guidance and troubleshooting:**
* Added notes in multiple labs (`LAB_03b`, `LAB_04`, `LAB_05`) to advise users to adjust configuration or region if deployments fail due to capacity or quota limits. This helps users quickly resolve common deployment issues. [[1]](diffhunk://#diff-b60ef4187858326951c698aa564f226408d2e79a90eda2a3cfba9fce79e7b318R66-R67) [[2]](diffhunk://#diff-72296d1cc27566457360c06528b96f691aee3c5cafb3e90d98f1597b64ed2eb5L67-R69) [[3]](diffhunk://#diff-8825c7ab11d694ba156426c294d09146307e20ff6fc865dd59b02e3d40016639R117-R118)

**Cloud Shell and subscription context:**
* Added step in `LAB_03b-Manage_Azure_Resources_by_Using_ARM_Templates.md` to verify and set the correct Azure subscription in Cloud Shell, especially when switching between PowerShell and Bash, to prevent accidental deployment to the wrong subscription.

**DNS naming and verification consistency:**
* Updated the DNS zone and related references from `contoso.com` to `contosoxyz104.com` in `LAB_04-Implement_Virtual_Networking.md` for uniqueness and to avoid naming conflicts; also updated nslookup and verification steps accordingly. [[1]](diffhunk://#diff-72296d1cc27566457360c06528b96f691aee3c5cafb3e90d98f1597b64ed2eb5L276-R278) [[2]](diffhunk://#diff-72296d1cc27566457360c06528b96f691aee3c5cafb3e90d98f1597b64ed2eb5L301-R306)
* Added explicit instruction to set "Alias record set" to "No" when creating a DNS record, clarifying the lab step.

**Resource cleanup instructions:**
* Clarified resource group deletion steps in `LAB_03b` and `LAB_05` to mention the need to confirm deletion in the dialog, ensuring users understand the permanence of the action. [[1]](diffhunk://#diff-b60ef4187858326951c698aa564f226408d2e79a90eda2a3cfba9fce79e7b318L254-R263) [[2]](diffhunk://#diff-8825c7ab11d694ba156426c294d09146307e20ff6fc865dd59b02e3d40016639L275-R283)

**Virtual machine connectivity:**
* Updated instructions in `LAB_05-Implement_Intersite_Connectivity.md` to enable the Windows Firewall rule for Remote Desktop on `CoreServicesVM` before testing connectivity, improving the reliability of RDP access during the lab.