### PR TITLE
Update 'Location' to 'Region' in lab instructions

### DIFF
--- a/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
+++ b/Instructions/Labs/LAB_02b-Manage_Governance_via_Azure_Policy.md
@@ -59,7 +59,7 @@ In this task, you will create and assign a tag to an Azure resource group via th
     | --- | --- |
     | Subscription name | your subscription |
     | Resource group name | `az104-rg2` |
-    | Location | **East US** |
+    | Region | **East US** |
 
     >**Note:** For each lab in this course you will create a new resource group. This lets you quickly locate and manage your lab resources. 
 


### PR DESCRIPTION
Lab 02b - Manage Governance via Azure Policy
Task 1: Assign tags via the Azure portal

Instruction
Search for and select Resource groups. Click + Create. Set Subscription to your subscription, Resource group name to az104-rg2, and Location to East US. Click Next to move to the Tags tab. Add a tag with Name = 'Cost Center' and Value = '000'. Click Review + Create, then Create.

Actual
The instructions reference "Location" as the field label, but the Azure portal form uses "Region" instead. The field was already set to "(US) East US" by default.

https://dev.azure.com/microsoftdigitallearning/Courseware/_queries/edit/171307/?queryId=cd7bd0cc-6e5a-4a19-b0a9-351cd522f04e