### PR TITLE
Update Lab07 instruction - Role assignment

### DIFF
--- a/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
+++ b/Instructions/Labs/LAB_07-Manage_Azure_Storage.md
@@ -132,7 +132,9 @@ In this task, you will create a blob container and upload an image. Blob contain
 
 1. In the storage account's left menu, select **Configuration** and set **Allow storage account key access** to **Enabled**, then click **Save**. 
 
-1. Next, navigate to **Access Control (IAM)**, click **Add role assignment**, select the **Storage Blob Data Contributor** role and **Storage File Data Privileged Contributor** role, assign it to your user account, and click **Review + assign**. 
+1. Next, navigate to **Access Control (IAM)**, click **Add role assignment**, select the **Storage Blob Data Contributor** role, and assign it to your user account, then click **Review + assign**.
+
+1. Next, do the same steps as in the previous step to assign the **Storage File Data Privileged Contributor** role.
 
 1. Once access is configured,  select your **data** container and then click **Upload**.
 


### PR DESCRIPTION
Clarified role assignment steps for blob uploads in Azure Storage instructions. 
It's not possible to assign 2 roles at the same time in portal.azure.com

# Module: 07
## Lab: 07

Fixes # .

Changes proposed in this pull request:

- Clarified role assignment steps for blob uploads in Azure Storage instructions. 
